### PR TITLE
Version/1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# donify
+> Versions and Changes
+
+## 1.0.1
+- Better handling of non-native promises
+- Invalid `promise` parameter now rejects with an Error instead of a string
+- Invalid `promise` parameter now calls done with an Error instead doing nothing
+- Improved docs in README.md
+- Added CHANGELOG.md
+
+## 1.0.0
+- Initial release

--- a/README.md
+++ b/README.md
@@ -17,24 +17,26 @@ const myFunction = function(flag, done) {
 };
 
 // If done is not defined, it returns the underlying promise
-myFunction(true)
-    .then((result) => {
-        // result is 'Success'
-    });
+var promiseSuccess = myFunction(true);
+promiseSuccess.then((result) => {
+    // result is 'Success'
+});
 
-myFunction(false)
-    .catch((err) => {
-        // err is 'Failure'
-    });
+var promiseSuccess = myFunction(false);
+promiseSuccess.catch((err) => {
+    // err is 'Failure'
+});
 
 // If you provide a done function, it gets called instead
-myFunction(true, (err, result) => {
+var doneSuccess = myFunction(true, (err, result) => {
     // err is null, result is 'Success'
 });
+// doneSuccess is true
 
-myFunction(false, (err, result) => {
+var doneFailure = myFunction(false, (err, result) => {
     // err is 'Failure', result is undefined
 });
+// doneFailure is true
 ```
 
 ## Installation
@@ -49,10 +51,36 @@ I can feel you judging this project, saying "For all things holy, why would you
 ever want to do this?!?!?!" As it turns out, when refactoring a huge project
 from callbacks to Promises, this is really helpful. By *donifying* your
 functions, you can incrementally convert from callbacks to Promises without
-having to do it all in one go. It also allows you to have older, callback-based
-packages seamlessly call your Promise based functions. I found myself writing
-this code over and over, so decided to simply pull it into a package with all
-the tests and stuff.
+having to do it all in one go. For example, say you have this legacy function:
+
+```javascript
+const myLegacyFunction = function(params, done) {
+    someCallbackFunction(params, (err, results) => {
+        done(err, results);
+    });
+};
+```
+
+You can easily rewrite it as:
+
+```javascript
+const donify = require('donify');
+const {promisify} = require('util');
+
+const myLegacyFunction = function(params, done) {
+    var promise = promisify(someCallbackFunction)(params);
+
+    return donify(promise, done);
+};
+```
+
+This retains 100% backward compatibility for your existing code but allows you
+to start refactoring to promises by eliminating the done callbacks as needed.
+It also allows you to have older, callback-based packages seamlessly call your
+Promise based functions.
+
+I found myself writing this code over and over, so decided to simply pull it
+into a package with all the tests and stuff.
 
 ## License
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,23 @@
 'use strict';
 
+// Per spec, a legit promise has a .then() function and that's about it...
+const isPromise = function(value) {
+    return Boolean(value && typeof value.then === 'function');
+};
+
 module.exports = function(promise, done) {
-    if(promise instanceof Promise) {
-        if(done && done instanceof Function) {
+    if(done && done instanceof Function) {
+        if(isPromise(promise)) {
             promise.then((results) => done(null, results)).catch(done);
             return true;
         }
-        return promise;
+
+        done(new Error('First parameter in donify() must be a Promise'));
+        return false;
     }
 
-    return Promise.reject('First parameter in donify() must be a Promise');
+    if(isPromise(promise)) {
+        return promise;
+    }
+    return Promise.reject(new Error('First parameter in donify() must be a Promise'));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
+        "async": "^3.2.3",
+        "bluebird": "^3.7.2",
         "chai": "^4.3.4",
         "chai-as-promised": "^7.1.1",
         "mocha": "^9.1.4",
@@ -577,6 +579,12 @@
         "node": "*"
       }
     },
+    "node_modules/async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -591,6 +599,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2891,6 +2905,12 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
+    "async": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
+      "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
+      "dev": true
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2901,6 +2921,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+      "dev": true
+    },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "brace-expansion": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "donify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "donify",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The opposite of promisify - convert a promise into a done callback",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "homepage": "https://github.com/gnickm/donify#readme",
   "devDependencies": {
+    "async": "^3.2.3",
+    "bluebird": "^3.7.2",
     "chai": "^4.3.4",
     "chai-as-promised": "^7.1.1",
     "mocha": "^9.1.4",


### PR DESCRIPTION
## 1.0.1
- Better handling of non-native promises
- Invalid `promise` parameter now rejects with an Error instead of a string
- Invalid `promise` parameter now calls done with an Error instead doing nothing
- Improved docs in README.md
- Added CHANGELOG.md
